### PR TITLE
Fix double enable of drawers and panels

### DIFF
--- a/Assets/Scenes/Empty.unity
+++ b/Assets/Scenes/Empty.unity
@@ -241,6 +241,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_enable: 1
+  m_defaultShapes: 1
   m_defaultMaterial: {fileID: 0}
   m_shapes: []
 --- !u!1 &770230239
@@ -468,7 +469,7 @@ GameObject:
   m_Icon: {fileID: 7866945982896999795, guid: 0000000000000000d000000000000000, type: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &1531290047
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -593,7 +594,7 @@ GameObject:
   m_Icon: {fileID: 4422084297763085224, guid: 0000000000000000d000000000000000, type: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1823135812
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/UGF.DebugTools.Runtime.Tests/UGF.DebugTools.Runtime.Tests.asmdef
+++ b/Assets/UGF.DebugTools.Runtime.Tests/UGF.DebugTools.Runtime.Tests.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "GUID:37dddc4e4de3de84f81310a1d1cd5e2c",
         "GUID:088d00b6871540e44bce58af1a3f0f17",
-        "GUID:6c7389a7d4bbed54e96eb1e71a69798e"
+        "GUID:6c7389a7d4bbed54e96eb1e71a69798e",
+        "GUID:d067af32d09350a4bb33960432735e4d"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Packages/UGF.DebugTools/Editor/DebugGLComponentEditor.cs
+++ b/Packages/UGF.DebugTools/Editor/DebugGLComponentEditor.cs
@@ -9,12 +9,14 @@ namespace UGF.DebugTools.Editor
     internal class DebugGLComponentEditor : UnityEditor.Editor
     {
         private SerializedProperty m_propertyEnable;
+        private SerializedProperty m_propertyDefaultShapes;
         private SerializedProperty m_propertyDefaultMaterial;
         private AssetReferenceListDrawer m_listShapes;
 
         private void OnEnable()
         {
             m_propertyEnable = serializedObject.FindProperty("m_enable");
+            m_propertyDefaultShapes = serializedObject.FindProperty("m_defaultShapes");
             m_propertyDefaultMaterial = serializedObject.FindProperty("m_defaultMaterial");
             m_listShapes = new AssetReferenceListDrawer(serializedObject.FindProperty("m_shapes"));
             m_listShapes.Enable();
@@ -30,6 +32,7 @@ namespace UGF.DebugTools.Editor
             using (new SerializedObjectUpdateScope(serializedObject))
             {
                 EditorGUILayout.PropertyField(m_propertyEnable);
+                EditorGUILayout.PropertyField(m_propertyDefaultShapes);
                 EditorGUILayout.PropertyField(m_propertyDefaultMaterial);
 
                 m_listShapes.DrawGUILayout();

--- a/Packages/UGF.DebugTools/Runtime/DebugGL.Shapes.cs
+++ b/Packages/UGF.DebugTools/Runtime/DebugGL.Shapes.cs
@@ -54,7 +54,7 @@ namespace UGF.DebugTools.Runtime
 
         public static void Shape(string id, Vector3 position, Quaternion rotation, Vector3 scale, Color color)
         {
-            Shape(id, position, rotation, scale, color, DefaultMaterial);
+            Shape(id, position, rotation, scale, color, Drawer.DefaultMaterial);
         }
 
         public static void Shape(string id, Vector3 position, Quaternion rotation, Vector3 scale, Color color, Material material)

--- a/Packages/UGF.DebugTools/Runtime/DebugGL.cs
+++ b/Packages/UGF.DebugTools/Runtime/DebugGL.cs
@@ -1,37 +1,22 @@
 ﻿using System;
-using UnityEngine;
 
 namespace UGF.DebugTools.Runtime
 {
     public static partial class DebugGL
     {
-        public static DebugGLDrawer Drawer { get; } = new DebugGLDrawer();
-        public static Material DefaultMaterial { get { return m_defaultMaterial != null ? m_defaultMaterial : throw new ArgumentException("Value not specified."); } }
-        public static bool HasDefaultMaterial { get { return m_defaultMaterial != null; } }
+        public static DebugGLDrawer Drawer { get { return m_drawer ?? throw new ArgumentException("Value not specified."); } }
+        public static bool HasDrawer { get { return m_drawer != null; } }
 
-        private static Material m_defaultMaterial;
+        private static DebugGLDrawer m_drawer;
 
-        static DebugGL()
+        public static void DrawerSet(DebugGLDrawer drawer)
         {
-            Drawer.AddShape(ShapeLineWireId, DebugGLUtility.CreateShapeLineWire());
-            Drawer.AddShape(ShapeTriangleWireId, DebugGLUtility.CreateShapeTriangleWire());
-            Drawer.AddShape(ShapeQuadWireId, DebugGLUtility.CreateShapeQuadWire());
-            Drawer.AddShape(ShapeCircleWireId, DebugGLUtility.CreateShapeCircleWire());
-            Drawer.AddShape(ShapeCubeWireId, DebugGLUtility.CreateShapeCubeWire());
-            Drawer.AddShape(ShapeSphereWireId, DebugGLUtility.CreateShapeSphereWire());
-            Drawer.AddShape(ShapeCylinderWireId, DebugGLUtility.CreateShapeCylinderWire());
+            m_drawer = drawer ?? throw new ArgumentNullException(nameof(drawer));
         }
 
-        public static void SetDefaultMaterial(Material material)
+        public static void DrawerClear()
         {
-            if (material == null) throw new ArgumentNullException(nameof(material));
-
-            m_defaultMaterial = material;
-        }
-
-        public static void ClearDefaultMaterial()
-        {
-            m_defaultMaterial = null;
+            m_drawer = null;
         }
     }
 }

--- a/Packages/UGF.DebugTools/Runtime/DebugGLComponent.cs
+++ b/Packages/UGF.DebugTools/Runtime/DebugGLComponent.cs
@@ -41,13 +41,16 @@ namespace UGF.DebugTools.Runtime
 
             m_drawer.SetDefaultMaterial(m_defaultMaterial ? m_defaultMaterial : DebugGLUtility.CreateDefaultMaterial());
 
-            m_drawer.AddShape(DebugGL.ShapeLineWireId, DebugGLUtility.CreateShapeLineWire());
-            m_drawer.AddShape(DebugGL.ShapeTriangleWireId, DebugGLUtility.CreateShapeTriangleWire());
-            m_drawer.AddShape(DebugGL.ShapeQuadWireId, DebugGLUtility.CreateShapeQuadWire());
-            m_drawer.AddShape(DebugGL.ShapeCircleWireId, DebugGLUtility.CreateShapeCircleWire());
-            m_drawer.AddShape(DebugGL.ShapeCubeWireId, DebugGLUtility.CreateShapeCubeWire());
-            m_drawer.AddShape(DebugGL.ShapeSphereWireId, DebugGLUtility.CreateShapeSphereWire());
-            m_drawer.AddShape(DebugGL.ShapeCylinderWireId, DebugGLUtility.CreateShapeCylinderWire());
+            if (m_defaultShapes)
+            {
+                m_drawer.AddShape(DebugGL.ShapeLineWireId, DebugGLUtility.CreateShapeLineWire());
+                m_drawer.AddShape(DebugGL.ShapeTriangleWireId, DebugGLUtility.CreateShapeTriangleWire());
+                m_drawer.AddShape(DebugGL.ShapeQuadWireId, DebugGLUtility.CreateShapeQuadWire());
+                m_drawer.AddShape(DebugGL.ShapeCircleWireId, DebugGLUtility.CreateShapeCircleWire());
+                m_drawer.AddShape(DebugGL.ShapeCubeWireId, DebugGLUtility.CreateShapeCubeWire());
+                m_drawer.AddShape(DebugGL.ShapeSphereWireId, DebugGLUtility.CreateShapeSphereWire());
+                m_drawer.AddShape(DebugGL.ShapeCylinderWireId, DebugGLUtility.CreateShapeCylinderWire());
+            }
 
             for (int i = 0; i < m_shapes.Count; i++)
             {

--- a/Packages/UGF.DebugTools/Runtime/DebugGLDrawer.cs
+++ b/Packages/UGF.DebugTools/Runtime/DebugGLDrawer.cs
@@ -2,18 +2,22 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using UGF.DebugTools.Runtime.GL.Scopes;
+using UGF.Initialize.Runtime;
 using UnityEngine;
 
 namespace UGF.DebugTools.Runtime
 {
-    public class DebugGLDrawer
+    public class DebugGLDrawer : InitializeBase
     {
         public bool Enable { get; set; } = true;
         public IReadOnlyDictionary<string, DebugGLShape> Shapes { get; }
         public IReadOnlyList<DebugGLDrawCommand> Commands { get; }
+        public Material DefaultMaterial { get { return m_defaultMaterial != null ? m_defaultMaterial : throw new ArgumentException("Value not specified."); } }
+        public bool HasDefaultMaterial { get { return m_defaultMaterial != null; } }
 
         private readonly Dictionary<string, DebugGLShape> m_shapes = new Dictionary<string, DebugGLShape>();
         private readonly List<DebugGLDrawCommand> m_commands = new List<DebugGLDrawCommand>();
+        private Material m_defaultMaterial;
 
         public DebugGLDrawer()
         {
@@ -34,6 +38,11 @@ namespace UGF.DebugTools.Runtime
             if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
 
             return m_shapes.Remove(id);
+        }
+
+        public void ClearShapes()
+        {
+            m_shapes.Clear();
         }
 
         public void AddCommand(DebugGLDrawCommand command)
@@ -93,6 +102,16 @@ namespace UGF.DebugTools.Runtime
                     UnityEngine.GL.Vertex(vertices[i]);
                 }
             }
+        }
+
+        public void SetDefaultMaterial(Material material)
+        {
+            m_defaultMaterial = material ? material : throw new ArgumentNullException(nameof(material));
+        }
+
+        public void ClearDefaultMaterial()
+        {
+            m_defaultMaterial = null;
         }
     }
 }

--- a/Packages/UGF.DebugTools/Runtime/DebugUI.Menu.cs
+++ b/Packages/UGF.DebugTools/Runtime/DebugUI.Menu.cs
@@ -119,6 +119,8 @@ namespace UGF.DebugTools.Runtime
                 };
 
                 Drawer.Add(id, drawer);
+
+                drawer.Initialize();
             }
 
             return drawer;

--- a/Packages/UGF.DebugTools/Runtime/DebugUI.Panel.cs
+++ b/Packages/UGF.DebugTools/Runtime/DebugUI.Panel.cs
@@ -25,10 +25,14 @@ namespace UGF.DebugTools.Runtime
         public static void PanelAdd(DebugUIPanel panel)
         {
             Drawer.Get<DebugUIPanelDrawer>().Add(panel);
+
+            panel.Initialize();
         }
 
         public static bool PanelRemove(DebugUIPanel panel)
         {
+            panel.Uninitialize();
+
             return Drawer.Get<DebugUIPanelDrawer>().Remove(panel);
         }
     }

--- a/Packages/UGF.DebugTools/Runtime/DebugUI.cs
+++ b/Packages/UGF.DebugTools/Runtime/DebugUI.cs
@@ -1,7 +1,22 @@
-﻿namespace UGF.DebugTools.Runtime
+﻿using System;
+
+namespace UGF.DebugTools.Runtime
 {
     public static partial class DebugUI
     {
-        public static DebugUIDrawer Drawer { get; } = new DebugUIDrawer();
+        public static DebugUIDrawer Drawer { get { return m_drawer ?? throw new ArgumentException("Value not specified."); } }
+        public static bool HasDrawer { get { return m_drawer != null; } }
+
+        private static DebugUIDrawer m_drawer;
+
+        public static void DrawerSet(DebugUIDrawer drawer)
+        {
+            m_drawer = drawer ?? throw new ArgumentNullException(nameof(drawer));
+        }
+
+        public static void DrawerClear()
+        {
+            m_drawer = null;
+        }
     }
 }

--- a/Packages/UGF.DebugTools/Runtime/DebugUIDrawerBase.cs
+++ b/Packages/UGF.DebugTools/Runtime/DebugUIDrawerBase.cs
@@ -1,28 +1,12 @@
-﻿namespace UGF.DebugTools.Runtime
+﻿using UGF.Initialize.Runtime;
+
+namespace UGF.DebugTools.Runtime
 {
-    public abstract class DebugUIDrawerBase : IDebugUIDrawer
+    public abstract class DebugUIDrawerBase : InitializeBase, IDebugUIDrawer
     {
-        public void Enable()
-        {
-            OnEnable();
-        }
-
-        public void Disable()
-        {
-            OnDisable();
-        }
-
         public void DrawGUI()
         {
             OnDrawGUI();
-        }
-
-        protected virtual void OnEnable()
-        {
-        }
-
-        protected virtual void OnDisable()
-        {
         }
 
         protected abstract void OnDrawGUI();

--- a/Packages/UGF.DebugTools/Runtime/IDebugUIDrawer.cs
+++ b/Packages/UGF.DebugTools/Runtime/IDebugUIDrawer.cs
@@ -1,9 +1,9 @@
-﻿namespace UGF.DebugTools.Runtime
+﻿using UGF.Initialize.Runtime;
+
+namespace UGF.DebugTools.Runtime
 {
-    public interface IDebugUIDrawer
+    public interface IDebugUIDrawer : IInitialize
     {
-        void Enable();
-        void Disable();
         void DrawGUI();
     }
 }

--- a/Packages/UGF.DebugTools/Runtime/UGF.DebugTools.Runtime.asmdef
+++ b/Packages/UGF.DebugTools/Runtime/UGF.DebugTools.Runtime.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "UGF.DebugTools.Runtime",
     "references": [
         "GUID:088d00b6871540e44bce58af1a3f0f17",
-        "GUID:6c7389a7d4bbed54e96eb1e71a69798e"
+        "GUID:6c7389a7d4bbed54e96eb1e71a69798e",
+        "GUID:d067af32d09350a4bb33960432735e4d"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Packages/UGF.DebugTools/Runtime/UI.Panels/DebugUIPanelDrawer.cs
+++ b/Packages/UGF.DebugTools/Runtime/UI.Panels/DebugUIPanelDrawer.cs
@@ -18,52 +18,52 @@ namespace UGF.DebugTools.Runtime.UI.Panels
             Panels = new ReadOnlyCollection<DebugUIPanel>(m_panels);
         }
 
+        protected override void OnInitialize()
+        {
+            base.OnInitialize();
+
+            for (int i = 0; i < m_panels.Count; i++)
+            {
+                m_panels[i].Initialize();
+            }
+
+            m_functionDisplay = DebugUI.AddFunction(DebugUI.DebugFunctionGroupName, "Panels Display", OnFunctionDisplay);
+        }
+
+        protected override void OnUninitialize()
+        {
+            base.OnUninitialize();
+
+            for (int i = 0; i < m_panels.Count; i++)
+            {
+                m_panels[i].Uninitialize();
+            }
+
+            DebugUI.RemoveFunction(DebugUI.DebugFunctionGroupName, m_functionDisplay);
+        }
+
         public void Add(DebugUIPanel panel)
         {
             if (panel == null) throw new ArgumentNullException(nameof(panel));
 
             m_panels.Add(panel);
-
-            panel.Enable();
         }
 
         public bool Remove(DebugUIPanel panel)
         {
             if (panel == null) throw new ArgumentNullException(nameof(panel));
 
-            if (m_panels.Remove(panel))
-            {
-                panel.Disable();
-                return true;
-            }
-
-            return false;
+            return m_panels.Remove(panel);
         }
 
         public void Clear()
         {
             for (int i = 0; i < m_panels.Count; i++)
             {
-                DebugUIPanel panel = m_panels[i];
-
-                panel.Disable();
+                m_panels[i].Uninitialize();
             }
 
             m_panels.Clear();
-        }
-
-        protected override void OnEnable()
-        {
-            base.OnEnable();
-
-            m_functionDisplay = DebugUI.AddFunction(DebugUI.DebugFunctionGroupName, "Panels Display", OnFunctionDisplay);
-        }
-
-        protected override void OnDisable()
-        {
-            base.OnDisable();
-
-            DebugUI.RemoveFunction(DebugUI.DebugFunctionGroupName, m_functionDisplay);
         }
 
         protected override void OnDrawGUI()

--- a/Packages/UGF.DebugTools/Runtime/UI.Sections/DebugUISection.cs
+++ b/Packages/UGF.DebugTools/Runtime/UI.Sections/DebugUISection.cs
@@ -1,8 +1,9 @@
 ﻿using System;
+using UGF.Initialize.Runtime;
 
 namespace UGF.DebugTools.Runtime.UI.Sections
 {
-    public abstract class DebugUISection
+    public abstract class DebugUISection : InitializeBase
     {
         public string DisplayName { get; }
 
@@ -11,16 +12,6 @@ namespace UGF.DebugTools.Runtime.UI.Sections
             if (string.IsNullOrEmpty(displayName)) throw new ArgumentException("Value cannot be null or empty.", nameof(displayName));
 
             DisplayName = displayName;
-        }
-
-        public void Enable()
-        {
-            OnEnable();
-        }
-
-        public void Disable()
-        {
-            OnDisable();
         }
 
         public void Select()
@@ -36,14 +27,6 @@ namespace UGF.DebugTools.Runtime.UI.Sections
         public void DrawGUILayout()
         {
             OnDrawGUILayout();
-        }
-
-        protected virtual void OnEnable()
-        {
-        }
-
-        protected virtual void OnDisable()
-        {
         }
 
         protected virtual void OnSelect()

--- a/Packages/UGF.DebugTools/Runtime/UI.Sections/DebugUISectionDrawer.cs
+++ b/Packages/UGF.DebugTools/Runtime/UI.Sections/DebugUISectionDrawer.cs
@@ -30,14 +30,36 @@ namespace UGF.DebugTools.Runtime.UI.Sections
             m_onMenuItemHandler = OnMenuSectionsSelected;
         }
 
+        protected override void OnInitialize()
+        {
+            base.OnInitialize();
+
+            foreach (KeyValuePair<string, DebugUISection> pair in m_sections)
+            {
+                pair.Value.Initialize();
+            }
+
+            m_functionDisplay = DebugUI.AddFunction(DebugUI.DebugFunctionGroupName, "Sections Display", OnFunctionDisplay);
+        }
+
+        protected override void OnUninitialize()
+        {
+            base.OnUninitialize();
+
+            foreach (KeyValuePair<string, DebugUISection> pair in m_sections)
+            {
+                pair.Value.Uninitialize();
+            }
+
+            DebugUI.RemoveFunction(DebugUI.DebugFunctionGroupName, m_functionDisplay);
+        }
+
         public void Add(string id, DebugUISection section)
         {
             if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
             if (section == null) throw new ArgumentNullException(nameof(section));
 
             m_sections.Add(id, section);
-
-            section.Enable();
         }
 
         public bool Remove(string id)
@@ -46,7 +68,6 @@ namespace UGF.DebugTools.Runtime.UI.Sections
 
             if (m_sections.TryGetValue(id, out DebugUISection section))
             {
-                section.Disable();
                 m_sections.Remove(id);
                 return true;
             }
@@ -60,7 +81,7 @@ namespace UGF.DebugTools.Runtime.UI.Sections
 
             foreach (KeyValuePair<string, DebugUISection> pair in m_sections)
             {
-                pair.Value.Disable();
+                pair.Value.Uninitialize();
             }
 
             m_sections.Clear();
@@ -94,30 +115,6 @@ namespace UGF.DebugTools.Runtime.UI.Sections
 
                 m_selected = string.Empty;
             }
-        }
-
-        protected override void OnEnable()
-        {
-            base.OnEnable();
-
-            foreach (KeyValuePair<string, DebugUISection> pair in m_sections)
-            {
-                pair.Value.Enable();
-            }
-
-            m_functionDisplay = DebugUI.AddFunction(DebugUI.DebugFunctionGroupName, "Sections Display", OnFunctionDisplay);
-        }
-
-        protected override void OnDisable()
-        {
-            base.OnDisable();
-
-            foreach (KeyValuePair<string, DebugUISection> pair in m_sections)
-            {
-                pair.Value.Disable();
-            }
-
-            DebugUI.RemoveFunction(DebugUI.DebugFunctionGroupName, m_functionDisplay);
         }
 
         protected override void OnUpdatePosition()

--- a/Packages/UGF.DebugTools/Runtime/UI.Sections/DebugUISectionOptions.cs
+++ b/Packages/UGF.DebugTools/Runtime/UI.Sections/DebugUISectionOptions.cs
@@ -14,9 +14,9 @@ namespace UGF.DebugTools.Runtime.UI.Sections
             m_onAlignmentSelect = OnAlignmentSelect;
         }
 
-        protected override void OnEnable()
+        protected override void OnInitialize()
         {
-            base.OnEnable();
+            base.OnInitialize();
 
             if (DebugUI.Drawer.TryGet(out DebugUISectionDrawer drawer))
             {
@@ -24,9 +24,9 @@ namespace UGF.DebugTools.Runtime.UI.Sections
             }
         }
 
-        protected override void OnDisable()
+        protected override void OnUninitialize()
         {
-            base.OnDisable();
+            base.OnUninitialize();
 
             m_drawer = null;
         }

--- a/Packages/UGF.DebugTools/package.json
+++ b/Packages/UGF.DebugTools/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "com.ugf.editortools": "1.13.1",
     "com.ugf.builder": "2.0.1",
+    "com.ugf.initialize": "2.6.0",
     "com.unity.modules.imgui": "1.0.0"
   }
 }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -14,11 +14,19 @@
       "dependencies": {
         "com.ugf.editortools": "1.13.1",
         "com.ugf.builder": "2.0.1",
+        "com.ugf.initialize": "2.6.0",
         "com.unity.modules.imgui": "1.0.0"
       }
     },
     "com.ugf.editortools": {
       "version": "1.13.1",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
+    },
+    "com.ugf.initialize": {
+      "version": "2.6.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {},


### PR DESCRIPTION
- Change dependencies: add `com.ugf.initialize` of `2.6.0` version.
- Add `DebugGLComponent.DefaultShapes` property to determine whether to register default shapes.
- Change `DebugGLDrawer` and `DebugUIDrawer` classes to implement initialization pattern.
- Change `DebugUISection` to inherit from `InitializeBase` class, and remove `Enable()` and `Disable()` methods.
- Change `IDebugUIDrawer` to inherit from `IInitialize` interface, and remove `Enable()` and `Disable()` methods.
- Change `DebugGL.Drawer` property to make it overridable using `DrawerSet()` and `DrawerClear()` methods.
- Change `DebugUI.Drawer` property to make it overridable using `DrawerSet()` and `DrawerClear()` methods.
- Change `DebugGLComponent` and `DebugUIComponent` to create drawers and register them in `DebugGL` and `DebugUI`.
- Remove `DebugGL.DefaultMaterial` property and related methods to control it, use `Drawer.DefaultMaterial` instead.